### PR TITLE
サーバースクリプトにて、日付A～Zのソートが動作しない

### DIFF
--- a/Implem.Pleasanter/Libraries/ServerScripts/ServerScriptUtilities.cs
+++ b/Implem.Pleasanter/Libraries/ServerScripts/ServerScriptUtilities.cs
@@ -424,7 +424,7 @@ namespace Implem.Pleasanter.Libraries.ServerScripts
                 {
                     view.ColumnSorterHash = new Dictionary<string, SqlOrderBy.Types>();
                 }
-                if (Enum.TryParse<SqlOrderBy.Types>(String(columnSorterHash, columnFilter.Key), out var value))
+                if (Enum.TryParse<SqlOrderBy.Types>(Value(columnSorterHash, columnFilter.Key).ToString(), out var value))
                 {
                     view.ColumnSorterHash[columnFilter.Key] = value;
                 }


### PR DESCRIPTION
バージョン1.2.1.0～1.2.5.2において、
サーバースクリプトにて、日付A～Zのソートが動作しないことを発見しましたので、修正したコードを共有いたします。

`view.Sorters.DateA = 'desc';`

原因箇所は、Implem.Pleasanter.Libraries.ServerScripts.ServerScriptUtilitiesの
SetColumnSorterHashValues()メソッドにあります。
項目値の取り出しにString()メソッドを呼んでいるため、本来"desc"の返りを期待するところ、
Types.ToDateTime(0)の結果(1899-12-30 00:00:00)が返り、
SqlOrderBy.Typesにキャストできず、読み飛ばしになっていると思われます。

修正後はバージョン=1.2.5.2にて正常動作することを確認しましたので、マージをご検討ください。

Resolves #38 